### PR TITLE
Inline-encode extension icons to avoid binary assets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+# Tab Clean Master
+
+Tab Clean Master 是一款基于 Chrome Manifest V3 的浏览器清理扩展，旨在提供当前页面清理、全局清理以及通用设置等完整功能模块。本仓库遵循阶段化开发流程，目前已完成基础架构的搭建。
+
+## 当前进度
+
+- [x] 创建项目目录结构
+- [x] 配置 Manifest V3 基础信息
+- [x] 构建弹窗与选项页的 UI 框架
+- [x] 实现选项卡切换与无障碍支持
+- [x] 封装存储与工具模块的初始版本
+- [x] 内联编码扩展图标以避免二进制文件依赖
+
+## 快速开始
+
+1. 打开 Chrome 浏览器并进入 `chrome://extensions/`。
+2. 开启开发者模式，点击“加载已解压的扩展程序”。
+3. 选择本仓库中的 `src` 目录即可加载插件。
+
+## 目录结构
+
+```
+project/
+├── src/
+│   ├── manifest.json
+│   ├── background/
+│   │   └── icon-service-worker.js
+│   ├── popup/
+│   │   ├── popup.html
+│   │   ├── popup.css
+│   │   └── popup.js
+│   ├── options/
+│   │   ├── options.html
+│   │   ├── options.css
+│   │   └── options.js
+│   └── common/
+│       ├── utils.js
+│       └── storage.js
+├── assets/
+│   └── images/
+└── docs/
+    └── README.md
+```
+
+## 内联图标说明
+
+仓库不再存储二进制 PNG 图标文件。扩展在后台 Service Worker 中通过 Base64 编码的图像数据生成工具栏图标，以满足“不提交二进制资源”的要求并保持加载效果一致。
+
+## 后续计划
+
+- 在弹窗中实现当前页面与全局清理逻辑。
+- 在选项页提供时间范围、自动清理等设置项。
+- 引入统一的视觉与交互反馈系统。
+- 完成文档化与自动化测试流程。

--- a/src/background/icon-service-worker.js
+++ b/src/background/icon-service-worker.js
@@ -1,0 +1,37 @@
+const ICON_BASE64 = {
+  16: "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAMElEQVR42mPgF9f6TwlmGMYG8C19iYGJNgCbZlyGMJCiGZshowbQIhaokg6GVl4AAOnoqIwX5vcOAAAAAElFTkSuQmCC",
+  32: "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAV0lEQVR42u3WMREAIAxD0SiAEQ/4RhwqQAJlyFHu/pA5b2qq2vp6GQEAAOA7QBnzGBsgUn6LkKP8BiFXeRQhZ3kEAQAAAAD5L2GKLUixhin+AV4yAAAc2anAf0e8GK1oAAAAAElFTkSuQmCC",
+  48: "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAh0lEQVR42u3Yuw2AQAwE0a0AQnqgb4qjCqgAJO6D7dUEzudFd7bWbb8qjwAAAAAAAAAAboDlOB8nLeAteiZGUfGjEIqMH4FQdHwvQhniexDKEt+KUKb4FgSAUoA/4r8iAAAAAKAQgIcMAL9Rk33AYiOz2IktrhIWdyGLyxzHXQAAAAAAAKBhbufyqb95VLSgAAAAAElFTkSuQmCC",
+  128: "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABgUlEQVR42u3dy3ECMQBEwYkAH8mBvAnOUUAOLhcfvT68BDR93JX2c7091G0OAQAHAYAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEACf1uX+++cAiA1eAzHDtyHM6G0MM34bwQzfhjDDtyHM+G0EM34bwYzfRjDjtxHM+G0EM34bwYzfRjDjtxEAAIDxywgAAMD4ZQQzfhsBAAAAAIDxswgAAMD4ZQQAAAAAAAAAYPwmAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACHwPAAAAAAAAAAAQ+C8AAAAg8G8gAAAAAAAEbgiBwB1BAAAAgXsCAQAAAncFQ+C2cAi8FwCBF0Mg8GaQV8MA8G4gAF4OBcDbwQB4PRyAAxF88/l9PYB3YTjlzI4C8AoIp53VkQD+E8TpZ5MAIAAEgAAQAAJAAAgASAAAHAIADgIAASAABAAAkAACAABIAAEgAAQAAJAAAgAAaCDegKkUCoFg1+/xQAAAABJRU5ErkJggg=="
+};
+
+async function base64ToImageData(size, base64) {
+  const response = await fetch(`data:image/png;base64,${base64}`);
+  const blob = await response.blob();
+  const bitmap = await createImageBitmap(blob);
+  const canvas = new OffscreenCanvas(size, size);
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(bitmap, 0, 0, size, size);
+  return ctx.getImageData(0, 0, size, size);
+}
+
+async function applyActionIcons() {
+  try {
+    const imageDataMap = {};
+    for (const [size, base64] of Object.entries(ICON_BASE64)) {
+      const numericSize = Number(size);
+      imageDataMap[numericSize] = await base64ToImageData(numericSize, base64);
+    }
+    await chrome.action.setIcon({ imageData: imageDataMap });
+  } catch (error) {
+    console.error("Failed to apply action icons", error);
+  }
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  applyActionIcons();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  applyActionIcons();
+});

--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -1,0 +1,121 @@
+/**
+ * storage.js 封装与 chrome.storage 的交互逻辑，便于未来扩展持久化策略。
+ */
+
+import { hasChromeRuntime } from "./utils.js";
+
+/**
+ * StorageService 提供统一的异步接口来读取和写入扩展配置。
+ */
+export class StorageService {
+  constructor(area = "sync") {
+    this.area = area;
+    this.ready = this.#init();
+    this.memoryFallback = {};
+  }
+
+  async #init() {
+    if (!hasChromeRuntime() || !chrome.storage || !chrome.storage[this.area]) {
+      console.warn(
+        `[Tab Clean Master] 当前环境缺少 chrome.storage.${this.area}，将使用内存存储作为回退方案。`
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * 读取存储中的键值。
+   * @param {string | string[]} keys
+   * @returns {Promise<Record<string, unknown>>}
+   */
+  async get(keys) {
+    const hasStorage = await this.ready;
+    if (!hasStorage) {
+      if (Array.isArray(keys)) {
+        return keys.reduce((acc, key) => {
+          acc[key] = this.memoryFallback[key];
+          return acc;
+        }, {});
+      }
+      if (typeof keys === "string") {
+        return { [keys]: this.memoryFallback[keys] };
+      }
+      return { ...this.memoryFallback };
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.storage[this.area].get(keys, resolve);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * 写入存储。
+   * @param {Record<string, unknown>} items
+   * @returns {Promise<void>}
+   */
+  async set(items) {
+    const hasStorage = await this.ready;
+    if (!hasStorage) {
+      Object.assign(this.memoryFallback, items);
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.storage[this.area].set(items, () => resolve());
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * 移除指定键。
+   * @param {string | string[]} keys
+   * @returns {Promise<void>}
+   */
+  async remove(keys) {
+    const hasStorage = await this.ready;
+    if (!hasStorage) {
+      if (Array.isArray(keys)) {
+        keys.forEach((key) => delete this.memoryFallback[key]);
+      } else {
+        delete this.memoryFallback[keys];
+      }
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.storage[this.area].remove(keys, () => resolve());
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * 清空存储区域。
+   * @returns {Promise<void>}
+   */
+  async clear() {
+    const hasStorage = await this.ready;
+    if (!hasStorage) {
+      this.memoryFallback = {};
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.storage[this.area].clear(() => resolve());
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+}

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,0 +1,29 @@
+/**
+ * 工具函数模块，集中管理通用的辅助方法。
+ * 随着项目推进可持续扩展，确保复用性与可测试性。
+ */
+
+/**
+ * 判断当前运行环境是否存在 chrome API。
+ * 在开发与测试环境中，某些 API 可能不可用，需要做兼容处理。
+ * @returns {boolean}
+ */
+export function hasChromeRuntime() {
+  return typeof chrome !== "undefined" && typeof chrome.runtime !== "undefined";
+}
+
+/**
+ * 一个空操作函数，作为默认回调占位符，避免函数存在性判断。
+ */
+export function noop() {}
+
+/**
+ * 等待指定的毫秒数，用于模拟异步流程或延迟操作。
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+export function wait(ms) {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Tab Clean Master",
+  "description": "一个用于清理当前页面和全部浏览数据的Chrome扩展，提供灵活的选项和友好的界面。",
+  "version": "0.1.0",
+  "action": {
+    "default_popup": "popup/popup.html",
+    "default_title": "Tab Clean Master"
+  },
+  "background": {
+    "service_worker": "background/icon-service-worker.js"
+  },
+  "options_page": "options/options.html",
+  "permissions": [
+    "storage",
+    "tabs",
+    "browsingData"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ]
+}

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,0 +1,113 @@
+:root {
+  color-scheme: light dark;
+  --layout-max-width: 880px;
+  --color-bg: #0b1120;
+  --color-card: rgba(15, 23, 42, 0.72);
+  --color-border: rgba(148, 163, 184, 0.18);
+  --color-text: #e2e8f0;
+  --color-text-muted: rgba(148, 163, 184, 0.75);
+  --color-accent: #38bdf8;
+  --color-placeholder: rgba(148, 163, 184, 0.28);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: radial-gradient(circle at top, #1d4ed8 0%, #0b1120 50%, #020617 100%);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 48px 16px;
+}
+
+.options {
+  width: min(100%, var(--layout-max-width));
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.options__header {
+  padding: 32px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.3), rgba(14, 165, 233, 0.12));
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 25px 45px -25px rgba(14, 165, 233, 0.6);
+}
+
+.options__header h1 {
+  margin: 0 0 12px;
+  font-size: 2rem;
+}
+
+.options__header p {
+  margin: 0;
+  line-height: 1.6;
+  color: var(--color-text);
+}
+
+.options__section {
+  background: var(--color-card);
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid var(--color-border);
+  display: grid;
+  gap: 16px;
+}
+
+.section__heading h2 {
+  margin: 0 0 8px;
+  font-size: 1.35rem;
+}
+
+.section__heading p {
+  margin: 0;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.section__placeholder {
+  min-height: 120px;
+  border: 2px dashed var(--color-placeholder);
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-placeholder);
+}
+
+.options__footer {
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  padding-bottom: 16px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: #f8fafc;
+    --color-card: rgba(255, 255, 255, 0.88);
+    --color-border: rgba(148, 163, 184, 0.22);
+    --color-text: #0f172a;
+    --color-text-muted: rgba(15, 23, 42, 0.55);
+    --color-placeholder: rgba(148, 163, 184, 0.55);
+  }
+
+  body {
+    background: linear-gradient(160deg, #e0f2fe 0%, #f8fafc 60%, #cbd5f5 100%);
+  }
+
+  .options__header {
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.25), rgba(14, 165, 233, 0.08));
+    color: var(--color-text);
+  }
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tab Clean Master · 通用选项</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main class="options" aria-label="Tab Clean Master 通用选项">
+      <header class="options__header">
+        <h1>通用选项配置</h1>
+        <p>
+          配置扩展的默认行为与自动化策略。当前阶段提供界面占位与信息说明，方便后续功能对接。
+        </p>
+      </header>
+      <section class="options__section" aria-labelledby="section-time">
+        <div class="section__heading">
+          <h2 id="section-time">时间范围</h2>
+          <p>预留 6 个时间范围选项，后续将绑定到清理逻辑中。</p>
+        </div>
+        <div class="section__placeholder" aria-hidden="true">功能开发中...</div>
+      </section>
+      <section class="options__section" aria-labelledby="section-data">
+        <div class="section__heading">
+          <h2 id="section-data">浏览数据类型</h2>
+          <p>规划多种可选清理数据类型，支持与弹窗保持一致。</p>
+        </div>
+        <div class="section__placeholder" aria-hidden="true">功能开发中...</div>
+      </section>
+      <section class="options__section" aria-labelledby="section-automation">
+        <div class="section__heading">
+          <h2 id="section-automation">自动清理</h2>
+          <p>将提供多场景触发自动清理的选项以及阈值设置。</p>
+        </div>
+        <div class="section__placeholder" aria-hidden="true">功能开发中...</div>
+      </section>
+      <footer class="options__footer">
+        <small>版本 0.1.0 · 架构搭建阶段</small>
+      </footer>
+    </main>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,0 +1,22 @@
+/**
+ * options.js 为通用设置页面提供基础的模块化结构。
+ * 当前阶段预留事件注册与存储交互接口，便于后续阶段直接扩展。
+ */
+
+import { StorageService } from "../common/storage.js";
+
+/**
+ * 负责初始化选项页面，未来将加载用户配置并绑定事件。
+ */
+async function initOptionsPage() {
+  try {
+    const storage = new StorageService();
+    await storage.ready;
+    // TODO: 在后续阶段填充界面并同步存储的设置。
+    console.info("[Tab Clean Master] 通用选项页面初始化完成。");
+  } catch (error) {
+    console.error("[Tab Clean Master] 初始化失败", error);
+  }
+}
+
+initOptionsPage();

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,0 +1,166 @@
+:root {
+  color-scheme: light dark;
+  --popup-width: 360px;
+  --popup-padding: 16px;
+  --color-bg: #0f172a;
+  --color-bg-soft: rgba(148, 163, 184, 0.12);
+  --color-border: rgba(148, 163, 184, 0.2);
+  --color-accent: #38bdf8;
+  --color-accent-strong: #0ea5e9;
+  --color-text: #f8fafc;
+  --color-text-muted: rgba(226, 232, 240, 0.72);
+  --color-placeholder: rgba(148, 163, 184, 0.35);
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: var(--popup-width);
+  font-family: "Inter", "PingFang SC", "Microsoft YaHei", sans-serif;
+  background: linear-gradient(135deg, #0b1120 0%, #1e293b 100%);
+  color: var(--color-text);
+}
+
+.popup {
+  padding: var(--popup-padding);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.popup__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.popup__title {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.04em;
+}
+
+.popup__subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.tabs {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.tabs__tab {
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-soft);
+  color: var(--color-text-muted);
+  border-radius: 10px;
+  padding: 8px 6px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tabs__tab:hover,
+.tabs__tab:focus-visible {
+  outline: none;
+  color: var(--color-text);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+.tabs__tab--active {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
+  color: #0f172a;
+  border-color: transparent;
+  box-shadow: 0 12px 24px -12px rgba(56, 189, 248, 0.75);
+}
+
+.panels {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel {
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--color-border);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.05);
+  transition: opacity 0.2s ease;
+}
+
+.panel[hidden] {
+  display: block;
+  opacity: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.panel--active {
+  opacity: 1;
+  position: relative;
+}
+
+.panel__title {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+}
+
+.panel__description {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+}
+
+.panel__placeholder {
+  display: grid;
+  place-items: center;
+  min-height: 80px;
+  border: 1px dashed var(--color-placeholder);
+  border-radius: 12px;
+  color: var(--color-placeholder);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.popup__footer {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  border-top: 1px solid var(--color-border);
+  padding-top: 8px;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --color-bg: #f8fafc;
+    --color-bg-soft: rgba(15, 23, 42, 0.03);
+    --color-border: rgba(15, 23, 42, 0.1);
+    --color-text: #0f172a;
+    --color-text-muted: rgba(15, 23, 42, 0.65);
+    --color-placeholder: rgba(15, 23, 42, 0.3);
+  }
+
+  body {
+    background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  }
+
+  .panel {
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.25);
+  }
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tab Clean Master</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <main class="popup" aria-label="Tab Clean Master 主界面">
+      <header class="popup__header">
+        <h1 class="popup__title">Tab Clean Master</h1>
+        <p class="popup__subtitle">快速清理浏览数据，保持工作流畅。</p>
+      </header>
+      <nav class="tabs" role="tablist" aria-label="清理功能选项卡">
+        <button
+          class="tabs__tab tabs__tab--active"
+          role="tab"
+          aria-selected="true"
+          aria-controls="tab-current"
+          id="tab-current-btn"
+          data-target="tab-current"
+        >
+          当前页面
+        </button>
+        <button
+          class="tabs__tab"
+          role="tab"
+          aria-selected="false"
+          aria-controls="tab-global"
+          id="tab-global-btn"
+          data-target="tab-global"
+        >
+          全部清理
+        </button>
+        <button
+          class="tabs__tab"
+          role="tab"
+          aria-selected="false"
+          aria-controls="tab-settings"
+          id="tab-settings-btn"
+          data-target="tab-settings"
+        >
+          通用选项
+        </button>
+      </nav>
+      <section class="panels">
+        <article
+          class="panel panel--active"
+          id="tab-current"
+          role="tabpanel"
+          aria-labelledby="tab-current-btn"
+        >
+          <h2 class="panel__title">当前页面清理</h2>
+          <p class="panel__description">
+            查看当前标签页的信息，并快速执行针对性的清理操作。后续阶段将补充清理选项和实时反馈。
+          </p>
+          <div class="panel__placeholder" aria-hidden="true">
+            <span>功能开发中...</span>
+          </div>
+        </article>
+        <article
+          class="panel"
+          id="tab-global"
+          role="tabpanel"
+          aria-labelledby="tab-global-btn"
+          hidden
+        >
+          <h2 class="panel__title">全部数据清理</h2>
+          <p class="panel__description">
+            对整个浏览器的数据进行清理，支持批量操作和进度反馈。将在后续阶段提供完整体验。
+          </p>
+          <div class="panel__placeholder" aria-hidden="true">
+            <span>功能开发中...</span>
+          </div>
+        </article>
+        <article
+          class="panel"
+          id="tab-settings"
+          role="tabpanel"
+          aria-labelledby="tab-settings-btn"
+          hidden
+        >
+          <h2 class="panel__title">通用选项</h2>
+          <p class="panel__description">
+            管理时间范围、自动清理和扩展行为等通用配置。该部分将在相关阶段完成。
+          </p>
+          <div class="panel__placeholder" aria-hidden="true">
+            <span>功能开发中...</span>
+          </div>
+        </article>
+      </section>
+      <footer class="popup__footer">
+        <small>版本 0.1.0 · 架构搭建阶段</small>
+      </footer>
+    </main>
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,0 +1,81 @@
+/**
+ * popup.js 负责处理弹窗中的基础交互逻辑。
+ * 当前阶段实现选项卡切换与基础状态同步，为后续功能扩展提供架构支持。
+ */
+
+/**
+ * @typedef {Object} TabElements
+ * @property {HTMLButtonElement} button - 与面板关联的选项卡按钮。
+ * @property {HTMLElement} panel - 需要展示的内容面板。
+ */
+
+const TAB_SELECTOR = '[role="tab"]';
+const PANEL_SELECTOR = '[role="tabpanel"]';
+
+/**
+ * 根据传入的目标 ID 激活对应的选项卡和内容面板。
+ * @param {Map<string, TabElements>} tabsMap - 维护按钮和面板映射的容器。
+ * @param {string} targetId - 需要显示的面板 ID。
+ */
+function activateTab(tabsMap, targetId) {
+  tabsMap.forEach(({ button, panel }, id) => {
+    const isActive = id === targetId;
+    button.classList.toggle('tabs__tab--active', isActive);
+    button.setAttribute('aria-selected', String(isActive));
+    panel.classList.toggle('panel--active', isActive);
+    panel.hidden = !isActive;
+  });
+}
+
+/**
+ * 初始化选项卡切换交互，包括点击和键盘箭头导航。
+ */
+function setupTabs() {
+  const buttons = Array.from(document.querySelectorAll(TAB_SELECTOR));
+  const panels = Array.from(document.querySelectorAll(PANEL_SELECTOR));
+
+  if (!buttons.length || buttons.length !== panels.length) {
+    console.warn('[Tab Clean Master] 选项卡结构未正确初始化。');
+    return;
+  }
+
+  /** @type {Map<string, TabElements>} */
+  const tabsMap = new Map();
+  buttons.forEach((button) => {
+    const targetId = button.dataset.target;
+    const panel = document.getElementById(targetId);
+    if (!targetId || !panel) {
+      console.warn('[Tab Clean Master] 未找到选项卡关联的面板：', targetId);
+      return;
+    }
+    tabsMap.set(targetId, { button, panel });
+  });
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const targetId = button.dataset.target;
+      if (targetId) {
+        activateTab(tabsMap, targetId);
+      }
+    });
+
+    button.addEventListener('keydown', (event) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+        return;
+      }
+
+      event.preventDefault();
+      const direction = event.key === 'ArrowRight' ? 1 : -1;
+      const currentIndex = buttons.indexOf(button);
+      const nextIndex = (currentIndex + direction + buttons.length) % buttons.length;
+      buttons[nextIndex].focus();
+      const targetId = buttons[nextIndex].dataset.target;
+      if (targetId) {
+        activateTab(tabsMap, targetId);
+      }
+    });
+  });
+}
+
+// 在模块加载后立即初始化交互逻辑，确保弹窗展示时可用。
+setupTabs();


### PR DESCRIPTION
## Summary
- remove committed PNG icon assets and register a background service worker that decodes Base64 strings into chrome.action icons
- update the manifest to use the new icon loader while keeping the popup and options entry points unchanged
- refresh project documentation to explain the text-only icon approach and new background directory

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e495c6c3e4833180b91c3add2cd9f1