### PR TITLE
feat: add current tab cleanup and general options

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -1,0 +1,102 @@
+export const STORAGE_KEYS = {
+  generalOptions: "generalOptions",
+};
+
+export const TIME_RANGE_OPTIONS = [
+  { id: "last15Minutes", label: "最近 15 分钟", seconds: 15 * 60 },
+  { id: "lastHour", label: "最近 1 小时", seconds: 60 * 60 },
+  { id: "last24Hours", label: "最近 24 小时", seconds: 24 * 60 * 60 },
+  { id: "last7Days", label: "最近 7 天", seconds: 7 * 24 * 60 * 60 },
+  { id: "last4Weeks", label: "最近 4 周", seconds: 28 * 24 * 60 * 60 },
+  { id: "forever", label: "全部时间", seconds: null },
+];
+
+export const DATA_TYPE_OPTIONS = [
+  { id: "cache", label: "缓存数据", key: "cache", supportsOrigins: true },
+  { id: "cookies", label: "Cookie", key: "cookies", supportsOrigins: true },
+  { id: "history", label: "历史记录", key: "history", supportsOrigins: false },
+  { id: "localStorage", label: "本地存储", key: "localStorage", supportsOrigins: true },
+  { id: "downloads", label: "下载记录", key: "downloads", supportsOrigins: false },
+  { id: "passwords", label: "已保存的密码", key: "passwords", supportsOrigins: false },
+];
+
+export const DEFAULT_GENERAL_SETTINGS = {
+  timeRange: "lastHour",
+  dataTypes: {
+    cache: true,
+    cookies: true,
+    history: false,
+    localStorage: false,
+    downloads: false,
+    passwords: false,
+  },
+  automation: {
+    enabled: false,
+    threshold: 20,
+  },
+};
+
+export const AUTOMATION_THRESHOLD = {
+  min: 5,
+  max: 50,
+};
+
+export function normalizeGeneralSettings(settings = {}) {
+  const normalized = {
+    timeRange: DEFAULT_GENERAL_SETTINGS.timeRange,
+    dataTypes: { ...DEFAULT_GENERAL_SETTINGS.dataTypes },
+    automation: { ...DEFAULT_GENERAL_SETTINGS.automation },
+  };
+
+  if (settings && typeof settings === "object") {
+    if (
+      typeof settings.timeRange === "string" &&
+      TIME_RANGE_OPTIONS.some((option) => option.id === settings.timeRange)
+    ) {
+      normalized.timeRange = settings.timeRange;
+    }
+
+    if (settings.dataTypes && typeof settings.dataTypes === "object") {
+      DATA_TYPE_OPTIONS.forEach(({ id }) => {
+        if (typeof settings.dataTypes[id] === "boolean") {
+          normalized.dataTypes[id] = settings.dataTypes[id];
+        }
+      });
+    }
+
+    if (settings.automation && typeof settings.automation === "object") {
+      if (typeof settings.automation.enabled === "boolean") {
+        normalized.automation.enabled = settings.automation.enabled;
+      }
+      const threshold = Number(settings.automation.threshold);
+      if (Number.isFinite(threshold)) {
+        const clamped = Math.min(
+          AUTOMATION_THRESHOLD.max,
+          Math.max(AUTOMATION_THRESHOLD.min, Math.round(threshold))
+        );
+        normalized.automation.threshold = clamped;
+      }
+    }
+  }
+
+  return normalized;
+}
+
+export function resolveSinceTimestamp(timeRangeId) {
+  const option = TIME_RANGE_OPTIONS.find((item) => item.id === timeRangeId);
+  if (!option) {
+    const fallback = TIME_RANGE_OPTIONS.find(
+      (item) => item.id === DEFAULT_GENERAL_SETTINGS.timeRange
+    );
+    if (!fallback || fallback.seconds === null) {
+      return 0;
+    }
+    return Date.now() - fallback.seconds * 1000;
+  }
+
+  if (option.seconds === null) {
+    return 0;
+  }
+
+  return Date.now() - option.seconds * 1000;
+}

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -33,6 +33,12 @@ body {
   gap: 24px;
 }
 
+.options__form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .options__header {
   padding: 32px;
   border-radius: 24px;
@@ -59,7 +65,7 @@ body {
   padding: 24px;
   border: 1px solid var(--color-border);
   display: grid;
-  gap: 16px;
+  gap: 20px;
 }
 
 .section__heading h2 {
@@ -73,16 +79,190 @@ body {
   line-height: 1.5;
 }
 
-.section__placeholder {
-  min-height: 120px;
-  border: 2px dashed var(--color-placeholder);
-  border-radius: 16px;
+.options__fieldset {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.options__grid {
   display: grid;
-  place-items: center;
+  gap: 12px;
+}
+
+.options__grid--time {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.options__grid--types {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.chip,
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--color-text);
   font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-placeholder);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.chip:hover,
+.toggle:hover,
+.chip:focus-within,
+.toggle:focus-within {
+  border-color: rgba(56, 189, 248, 0.65);
+  background: rgba(56, 189, 248, 0.18);
+  transform: translateY(-1px);
+}
+
+.chip input,
+.toggle input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-accent);
+}
+
+.automation {
+  display: grid;
+  gap: 16px;
+}
+
+.switch {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.switch input {
+  display: none;
+}
+
+.switch__control {
+  position: relative;
+  width: 48px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.4);
+  transition: background 0.2s ease;
+}
+
+.switch__control::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s ease;
+}
+
+.switch input:checked + .switch__control {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.8), rgba(14, 165, 233, 0.9));
+}
+
+.switch input:checked + .switch__control::after {
+  transform: translateX(20px);
+}
+
+.switch__label {
+  font-size: 0.95rem;
+}
+
+.automation__threshold {
+  display: grid;
+  gap: 8px;
+}
+
+.automation__threshold label {
+  font-weight: 600;
+}
+
+.automation__threshold input {
+  width: 120px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.automation__threshold input:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.4);
+  outline-offset: 2px;
+}
+
+.automation__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.options__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 18px;
+  padding: 16px 20px;
+  border: 1px solid var(--color-border);
+}
+
+.options__reset {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  color: #0f172a;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.9));
+  box-shadow: 0 12px 24px -12px rgba(56, 189, 248, 0.7);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.options__reset:hover,
+.options__reset:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px -12px rgba(56, 189, 248, 0.85);
+}
+
+.options__status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  min-height: 1.2em;
+}
+
+.options__status[data-tone="error"] {
+  color: #fda4af;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .options__footer {
@@ -109,5 +289,21 @@ body {
   .options__header {
     background: linear-gradient(135deg, rgba(56, 189, 248, 0.25), rgba(14, 165, 233, 0.08));
     color: var(--color-text);
+  }
+
+  .chip,
+  .toggle {
+    background: rgba(255, 255, 255, 0.9);
+    border-color: rgba(148, 163, 184, 0.2);
+  }
+
+  .automation__threshold input {
+    background: rgba(255, 255, 255, 0.9);
+    border-color: rgba(148, 163, 184, 0.35);
+    color: inherit;
+  }
+
+  .options__actions {
+    background: rgba(255, 255, 255, 0.92);
   }
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,30 +11,110 @@
       <header class="options__header">
         <h1>通用选项配置</h1>
         <p>
-          配置扩展的默认行为与自动化策略。当前阶段提供界面占位与信息说明，方便后续功能对接。
+          配置扩展的默认清理行为与自动化策略。所有设置会自动保存，并与弹窗内的“当前页面”功能保持同步。
         </p>
       </header>
-      <section class="options__section" aria-labelledby="section-time">
-        <div class="section__heading">
-          <h2 id="section-time">时间范围</h2>
-          <p>预留 6 个时间范围选项，后续将绑定到清理逻辑中。</p>
+      <form class="options__form" id="options-form" novalidate>
+        <section class="options__section" aria-labelledby="section-time">
+          <div class="section__heading">
+            <h2 id="section-time">默认时间范围</h2>
+            <p>选择在执行清理操作时应追溯的时间段。</p>
+          </div>
+          <fieldset class="options__fieldset" role="radiogroup" aria-labelledby="section-time">
+            <legend class="sr-only">时间范围</legend>
+            <div class="options__grid options__grid--time">
+              <label class="chip">
+                <input type="radio" name="timeRange" value="last15Minutes" />
+                <span>最近 15 分钟</span>
+              </label>
+              <label class="chip">
+                <input type="radio" name="timeRange" value="lastHour" />
+                <span>最近 1 小时</span>
+              </label>
+              <label class="chip">
+                <input type="radio" name="timeRange" value="last24Hours" />
+                <span>最近 24 小时</span>
+              </label>
+              <label class="chip">
+                <input type="radio" name="timeRange" value="last7Days" />
+                <span>最近 7 天</span>
+              </label>
+              <label class="chip">
+                <input type="radio" name="timeRange" value="last4Weeks" />
+                <span>最近 4 周</span>
+              </label>
+              <label class="chip">
+                <input type="radio" name="timeRange" value="forever" />
+                <span>全部时间</span>
+              </label>
+            </div>
+          </fieldset>
+        </section>
+        <section class="options__section" aria-labelledby="section-data">
+          <div class="section__heading">
+            <h2 id="section-data">默认清理数据类型</h2>
+            <p>这些数据类型会在弹窗中默认勾选，可按需启用或禁用。</p>
+          </div>
+          <div class="options__grid options__grid--types">
+            <label class="toggle">
+              <input type="checkbox" value="cache" data-type />
+              <span>缓存数据</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" value="cookies" data-type />
+              <span>Cookie</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" value="history" data-type />
+              <span>历史记录</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" value="localStorage" data-type />
+              <span>本地存储</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" value="downloads" data-type />
+              <span>下载记录</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" value="passwords" data-type />
+              <span>已保存的密码</span>
+            </label>
+          </div>
+        </section>
+        <section class="options__section" aria-labelledby="section-automation">
+          <div class="section__heading">
+            <h2 id="section-automation">自动清理策略</h2>
+            <p>在达到指定条件时自动执行默认的清理策略。</p>
+          </div>
+          <div class="automation">
+            <label class="switch">
+              <input type="checkbox" data-automation="enabled" />
+              <span class="switch__control" aria-hidden="true"></span>
+              <span class="switch__label">启用自动清理</span>
+            </label>
+            <div class="automation__threshold">
+              <label for="automation-threshold">标签页数量阈值</label>
+              <input
+                id="automation-threshold"
+                type="number"
+                inputmode="numeric"
+                min="5"
+                max="50"
+                step="1"
+                data-automation="threshold"
+              />
+              <p class="automation__hint">
+                当打开的标签页数量超过该值时，将提示执行一次默认清理。
+              </p>
+            </div>
+          </div>
+        </section>
+        <div class="options__actions">
+          <button type="button" class="options__reset" data-reset>恢复默认设置</button>
+          <p class="options__status" role="status" aria-live="polite" data-status></p>
         </div>
-        <div class="section__placeholder" aria-hidden="true">功能开发中...</div>
-      </section>
-      <section class="options__section" aria-labelledby="section-data">
-        <div class="section__heading">
-          <h2 id="section-data">浏览数据类型</h2>
-          <p>规划多种可选清理数据类型，支持与弹窗保持一致。</p>
-        </div>
-        <div class="section__placeholder" aria-hidden="true">功能开发中...</div>
-      </section>
-      <section class="options__section" aria-labelledby="section-automation">
-        <div class="section__heading">
-          <h2 id="section-automation">自动清理</h2>
-          <p>将提供多场景触发自动清理的选项以及阈值设置。</p>
-        </div>
-        <div class="section__placeholder" aria-hidden="true">功能开发中...</div>
-      </section>
+      </form>
       <footer class="options__footer">
         <small>版本 0.1.0 · 架构搭建阶段</small>
       </footer>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -4,18 +4,186 @@
  */
 
 import { StorageService } from "../common/storage.js";
+import {
+  STORAGE_KEYS,
+  DEFAULT_GENERAL_SETTINGS,
+  normalizeGeneralSettings,
+  AUTOMATION_THRESHOLD,
+} from "../common/settings.js";
+
+const STATUS_DURATION = 3200;
+
+const form = document.getElementById("options-form");
+const statusElement = document.querySelector("[data-status]");
+const resetButton = document.querySelector("[data-reset]");
+
+let storage;
+let statusTimer;
+let currentSettings = normalizeGeneralSettings(DEFAULT_GENERAL_SETTINGS);
+
+function showStatus(message, tone = "info") {
+  if (!statusElement) {
+    return;
+  }
+
+  window.clearTimeout(statusTimer);
+  statusElement.textContent = message;
+  statusElement.dataset.tone = tone;
+  statusTimer = window.setTimeout(() => {
+    statusElement.textContent = "";
+    delete statusElement.dataset.tone;
+  }, STATUS_DURATION);
+}
+
+function readSettingsFromForm() {
+  if (!form) {
+    return currentSettings;
+  }
+
+  const formData = new FormData(form);
+  const timeRange = formData.get("timeRange") || currentSettings.timeRange;
+
+  const dataTypes = { ...currentSettings.dataTypes };
+  const checkboxes = form.querySelectorAll("input[data-type]");
+  checkboxes.forEach((checkbox) => {
+    dataTypes[checkbox.value] = checkbox.checked;
+  });
+
+  const automationEnabledInput = form.querySelector(
+    "input[data-automation=\"enabled\"]"
+  );
+  const automationThresholdInput = form.querySelector(
+    "input[data-automation=\"threshold\"]"
+  );
+
+  const automation = {
+    enabled: automationEnabledInput ? automationEnabledInput.checked : false,
+    threshold: automationThresholdInput
+      ? Number.parseInt(automationThresholdInput.value, 10)
+      : currentSettings.automation.threshold,
+  };
+
+  return normalizeGeneralSettings({ timeRange, dataTypes, automation });
+}
+
+function applySettingsToForm(settings) {
+  if (!form) {
+    return;
+  }
+
+  const timeInputs = form.querySelectorAll('input[name="timeRange"]');
+  timeInputs.forEach((input) => {
+    input.checked = input.value === settings.timeRange;
+  });
+
+  const dataInputs = form.querySelectorAll("input[data-type]");
+  dataInputs.forEach((input) => {
+    input.checked = Boolean(settings.dataTypes[input.value]);
+  });
+
+  const automationEnabledInput = form.querySelector(
+    "input[data-automation=\"enabled\"]"
+  );
+  if (automationEnabledInput) {
+    automationEnabledInput.checked = Boolean(settings.automation.enabled);
+  }
+
+  const automationThresholdInput = form.querySelector(
+    "input[data-automation=\"threshold\"]"
+  );
+  if (automationThresholdInput) {
+    automationThresholdInput.value = String(settings.automation.threshold);
+  }
+}
+
+async function persistSettings(settings) {
+  try {
+    await storage.set({ [STORAGE_KEYS.generalOptions]: settings });
+    currentSettings = settings;
+    showStatus("设置已保存");
+  } catch (error) {
+    console.error("[Tab Clean Master] 保存设置失败", error);
+    showStatus("保存设置时出现问题，请稍后重试", "error");
+  }
+}
+
+function handleFormChange() {
+  if (!form) {
+    return;
+  }
+
+  const newSettings = readSettingsFromForm();
+  applySettingsToForm(newSettings);
+  persistSettings(newSettings);
+}
+
+function handleThresholdInput(eventOrElement) {
+  const input =
+    eventOrElement instanceof HTMLInputElement
+      ? eventOrElement
+      : eventOrElement?.target;
+  if (!(input instanceof HTMLInputElement)) {
+    return;
+  }
+
+  const value = Number.parseInt(input.value, 10);
+  if (!Number.isFinite(value)) {
+    return;
+  }
+
+  const clamped = Math.min(
+    AUTOMATION_THRESHOLD.max,
+    Math.max(AUTOMATION_THRESHOLD.min, value)
+  );
+
+  if (clamped !== value) {
+    input.value = String(clamped);
+  }
+}
+
+function restoreDefaults() {
+  const defaults = normalizeGeneralSettings(DEFAULT_GENERAL_SETTINGS);
+  applySettingsToForm(defaults);
+  persistSettings(defaults);
+  showStatus("已恢复默认设置");
+}
 
 /**
  * 负责初始化选项页面，未来将加载用户配置并绑定事件。
  */
 async function initOptionsPage() {
   try {
-    const storage = new StorageService();
+    if (!form) {
+      console.warn("[Tab Clean Master] 未找到选项表单节点。");
+      return;
+    }
+
+    storage = new StorageService();
     await storage.ready;
-    // TODO: 在后续阶段填充界面并同步存储的设置。
+
+    const stored = await storage.get(STORAGE_KEYS.generalOptions);
+    currentSettings = normalizeGeneralSettings(
+      stored[STORAGE_KEYS.generalOptions]
+    );
+    applySettingsToForm(currentSettings);
+
+    form.addEventListener("change", handleFormChange);
+    const thresholdInput = form.querySelector(
+      "input[data-automation=\"threshold\"]"
+    );
+    if (thresholdInput) {
+      thresholdInput.addEventListener("input", handleThresholdInput);
+      handleThresholdInput(thresholdInput);
+    }
+
+    if (resetButton) {
+      resetButton.addEventListener("click", restoreDefaults);
+    }
+
     console.info("[Tab Clean Master] 通用选项页面初始化完成。");
   } catch (error) {
     console.error("[Tab Clean Master] 初始化失败", error);
+    showStatus("初始化失败，请刷新页面重试", "error");
   }
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -137,6 +137,170 @@ body {
   text-transform: uppercase;
 }
 
+.current-tab {
+  display: grid;
+  gap: 12px;
+}
+
+.current-tab__summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.current-tab__favicon {
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.current-tab__details {
+  display: grid;
+  gap: 4px;
+}
+
+.current-tab__title {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.current-tab__url {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  word-break: break-all;
+}
+
+.current-tab__form {
+  display: grid;
+  gap: 14px;
+}
+
+.current-tab__group {
+  display: grid;
+  gap: 8px;
+}
+
+.current-tab__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.current-tab__form select {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.current-tab__form select:focus {
+  outline: 2px solid rgba(56, 189, 248, 0.4);
+  outline-offset: 2px;
+}
+
+.current-tab__types {
+  display: grid;
+  gap: 8px;
+}
+
+.current-tab__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.4);
+  font-size: 0.8rem;
+  color: var(--color-text);
+}
+
+.current-tab__checkbox input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-accent);
+}
+
+.current-tab__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.current-tab__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.current-tab__submit {
+  flex: 1;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: #0f172a;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
+  box-shadow: 0 12px 24px -14px rgba(56, 189, 248, 0.75);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.current-tab__submit:hover,
+.current-tab__submit:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px -14px rgba(56, 189, 248, 0.85);
+}
+
+.current-tab__secondary {
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.current-tab__secondary:hover,
+.current-tab__secondary:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  background: rgba(56, 189, 248, 0.15);
+}
+
+.current-tab__status {
+  margin: 0;
+  min-height: 1.2em;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.current-tab__status[data-tone="info"] {
+  color: var(--color-text-muted);
+}
+
+.current-tab__status[data-tone="success"] {
+  color: #bbf7d0;
+}
+
+.current-tab__status[data-tone="error"] {
+  color: #fca5a5;
+}
+
+.current-tab__status[data-tone="warning"] {
+  color: #fde68a;
+}
+
 .popup__footer {
   text-align: center;
   font-size: 0.75rem;
@@ -162,5 +326,22 @@ body {
   .panel {
     background: rgba(255, 255, 255, 0.85);
     box-shadow: 0 10px 30px -20px rgba(15, 23, 42, 0.25);
+  }
+
+  .current-tab__summary {
+    background: rgba(248, 250, 252, 0.9);
+  }
+
+  .current-tab__form select {
+    background: rgba(248, 250, 252, 0.95);
+    color: inherit;
+  }
+
+  .current-tab__checkbox {
+    background: rgba(248, 250, 252, 0.8);
+  }
+
+  .current-tab__secondary {
+    background: rgba(248, 250, 252, 0.85);
   }
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -53,11 +53,76 @@
         >
           <h2 class="panel__title">当前页面清理</h2>
           <p class="panel__description">
-            查看当前标签页的信息，并快速执行针对性的清理操作。后续阶段将补充清理选项和实时反馈。
+            查看当前标签页的信息，并快速执行针对性的清理操作。可以按需调整时间范围与数据类型。
           </p>
-          <div class="panel__placeholder" aria-hidden="true">
-            <span>功能开发中...</span>
-          </div>
+          <section class="current-tab" aria-live="polite">
+            <header class="current-tab__summary">
+              <img
+                src=""
+                alt=""
+                class="current-tab__favicon"
+                width="32"
+                height="32"
+                data-current-favicon
+              />
+              <div class="current-tab__details">
+                <h3 class="current-tab__title" data-current-title>正在读取标签信息...</h3>
+                <p class="current-tab__url" data-current-url></p>
+              </div>
+            </header>
+            <form class="current-tab__form" data-current-form>
+              <div class="current-tab__group">
+                <label class="current-tab__label" for="current-time-range">清理时间范围</label>
+                <select id="current-time-range" name="timeRange" data-current-range>
+                  <option value="last15Minutes">最近 15 分钟</option>
+                  <option value="lastHour">最近 1 小时</option>
+                  <option value="last24Hours">最近 24 小时</option>
+                  <option value="last7Days">最近 7 天</option>
+                  <option value="last4Weeks">最近 4 周</option>
+                  <option value="forever">全部时间</option>
+                </select>
+              </div>
+              <fieldset class="current-tab__group" aria-describedby="current-types-hint">
+                <legend class="current-tab__label">需要清理的数据类型</legend>
+                <div class="current-tab__types" id="current-types">
+                  <label class="current-tab__checkbox">
+                    <input type="checkbox" value="cache" data-current-type />
+                    <span>缓存数据</span>
+                  </label>
+                  <label class="current-tab__checkbox">
+                    <input type="checkbox" value="cookies" data-current-type />
+                    <span>Cookie</span>
+                  </label>
+                  <label class="current-tab__checkbox">
+                    <input type="checkbox" value="history" data-current-type />
+                    <span>历史记录</span>
+                  </label>
+                  <label class="current-tab__checkbox">
+                    <input type="checkbox" value="localStorage" data-current-type />
+                    <span>本地存储</span>
+                  </label>
+                  <label class="current-tab__checkbox">
+                    <input type="checkbox" value="downloads" data-current-type />
+                    <span>下载记录</span>
+                  </label>
+                  <label class="current-tab__checkbox">
+                    <input type="checkbox" value="passwords" data-current-type />
+                    <span>已保存的密码</span>
+                  </label>
+                </div>
+                <p class="current-tab__hint" id="current-types-hint">
+                  默认勾选项可在通用选项中配置。
+                </p>
+              </fieldset>
+              <div class="current-tab__actions">
+                <button type="submit" class="current-tab__submit">立即清理</button>
+                <button type="button" class="current-tab__secondary" data-apply-defaults>
+                  恢复默认
+                </button>
+              </div>
+              <p class="current-tab__status" role="status" aria-live="polite" data-current-status></p>
+            </form>
+          </section>
         </article>
         <article
           class="panel"

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,7 +1,17 @@
 /**
  * popup.js 负责处理弹窗中的基础交互逻辑。
- * 当前阶段实现选项卡切换与基础状态同步，为后续功能扩展提供架构支持。
+ * 当前阶段实现选项卡切换、当前页面清理功能及状态反馈，为后续功能扩展提供架构支持。
  */
+
+import { StorageService } from "../common/storage.js";
+import {
+  STORAGE_KEYS,
+  DEFAULT_GENERAL_SETTINGS,
+  normalizeGeneralSettings,
+  resolveSinceTimestamp,
+  DATA_TYPE_OPTIONS,
+} from "../common/settings.js";
+import { hasChromeRuntime } from "../common/utils.js";
 
 /**
  * @typedef {Object} TabElements
@@ -79,3 +89,204 @@ function setupTabs() {
 
 // 在模块加载后立即初始化交互逻辑，确保弹窗展示时可用。
 setupTabs();
+
+/**
+ * 初始化“当前页面”面板，读取默认设置并绑定清理逻辑。
+ */
+async function initCurrentTabPanel() {
+  const form = document.querySelector("[data-current-form]");
+  if (!form) {
+    return;
+  }
+
+  const statusElement = document.querySelector("[data-current-status]");
+  const applyDefaultsButton = document.querySelector("[data-apply-defaults]");
+  const rangeSelect = document.querySelector("[data-current-range]");
+  const typeInputs = Array.from(document.querySelectorAll("[data-current-type]"));
+  const titleElement = document.querySelector("[data-current-title]");
+  const urlElement = document.querySelector("[data-current-url]");
+  const faviconElement = document.querySelector("[data-current-favicon]");
+
+  let statusTimer;
+  let currentTab = null;
+  let generalDefaults = normalizeGeneralSettings(DEFAULT_GENERAL_SETTINGS);
+  const storage = new StorageService();
+  await storage.ready;
+
+  function showStatus(message, tone = "info") {
+    if (!statusElement) {
+      return;
+    }
+
+    window.clearTimeout(statusTimer);
+    statusElement.textContent = message;
+    statusElement.dataset.tone = tone;
+    statusTimer = window.setTimeout(() => {
+      statusElement.textContent = "";
+      delete statusElement.dataset.tone;
+    }, 3200);
+  }
+
+  function applySettings(settings) {
+    if (rangeSelect) {
+      rangeSelect.value = settings.timeRange;
+    }
+
+    typeInputs.forEach((input) => {
+      input.checked = Boolean(settings.dataTypes[input.value]);
+    });
+  }
+
+  function collectSelection() {
+    const selected = typeInputs
+      .filter((input) => input.checked)
+      .map((input) => input.value);
+    return selected;
+  }
+
+  function updateTabSummary(tab) {
+    if (!titleElement || !urlElement || !faviconElement) {
+      return;
+    }
+
+    if (!tab) {
+      titleElement.textContent = "无法获取当前标签页";
+      urlElement.textContent = "请确认扩展拥有标签页权限";
+      faviconElement.src = "../assets/icons/icon32.png";
+      faviconElement.alt = "Tab Clean Master";
+      return;
+    }
+
+    titleElement.textContent = tab.title || "未命名标签页";
+    urlElement.textContent = tab.url || "";
+    faviconElement.src = tab.favIconUrl || "../assets/icons/icon32.png";
+    faviconElement.alt = tab.title || "当前站点";
+  }
+
+  async function fetchCurrentTab() {
+    if (!hasChromeRuntime() || !chrome.tabs || !chrome.tabs.query) {
+      return null;
+    }
+
+    try {
+      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+      return tabs[0] || null;
+    } catch (error) {
+      console.error("[Tab Clean Master] 读取标签页信息失败", error);
+      return null;
+    }
+  }
+
+  function buildRemovalPayload(selectedTypes) {
+    const originScoped = {};
+    const globalScoped = {};
+
+    selectedTypes.forEach((id) => {
+      const option = DATA_TYPE_OPTIONS.find((item) => item.id === id);
+      if (!option) {
+        return;
+      }
+
+      if (option.supportsOrigins) {
+        originScoped[option.key] = true;
+      } else {
+        globalScoped[option.key] = true;
+      }
+    });
+
+    return { originScoped, globalScoped };
+  }
+
+  function executeRemoval(options, dataToRemove) {
+    return new Promise((resolve, reject) => {
+      try {
+        chrome.browsingData.remove(options, dataToRemove, () => {
+          const error = chrome.runtime?.lastError;
+          if (error) {
+            reject(new Error(error.message));
+            return;
+          }
+          resolve();
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+
+    const selectedTypes = collectSelection();
+    if (!selectedTypes.length) {
+      showStatus("请至少选择一种需要清理的数据类型", "error");
+      return;
+    }
+
+    if (!hasChromeRuntime() || !chrome.browsingData || !chrome.browsingData.remove) {
+      showStatus("当前环境不支持浏览数据清理。", "error");
+      return;
+    }
+
+    if (!currentTab || !currentTab.url) {
+      showStatus("无法获取当前标签页地址。", "error");
+      return;
+    }
+
+    const since = resolveSinceTimestamp(rangeSelect?.value || generalDefaults.timeRange);
+    const { originScoped, globalScoped } = buildRemovalPayload(selectedTypes);
+
+    let origin = null;
+    try {
+      origin = new URL(currentTab.url).origin;
+    } catch (error) {
+      console.warn("[Tab Clean Master] 无法解析当前页面 URL", error);
+    }
+
+    if (!origin && Object.keys(originScoped).length) {
+      showStatus("无法解析当前站点，将针对全部数据进行清理。", "warning");
+    }
+
+    showStatus("正在清理中，请稍候…", "info");
+
+    try {
+      const tasks = [];
+      if (Object.keys(originScoped).length) {
+        const options = { since };
+        if (origin) {
+          options.origins = [origin];
+        }
+        tasks.push(executeRemoval(options, originScoped));
+      }
+
+      if (Object.keys(globalScoped).length) {
+        const options = { since };
+        tasks.push(executeRemoval(options, globalScoped));
+      }
+
+      await Promise.all(tasks);
+      showStatus("清理完成！", "success");
+    } catch (error) {
+      console.error("[Tab Clean Master] 清理失败", error);
+      showStatus("清理过程中出现问题，请稍后重试。", "error");
+    }
+  }
+
+  if (applyDefaultsButton) {
+    applyDefaultsButton.addEventListener("click", () => {
+      applySettings(generalDefaults);
+      showStatus("已应用默认设置", "info");
+    });
+  }
+
+  form.addEventListener("submit", handleSubmit);
+
+  const stored = await storage.get(STORAGE_KEYS.generalOptions);
+  generalDefaults = normalizeGeneralSettings(stored[STORAGE_KEYS.generalOptions]);
+  applySettings(generalDefaults);
+
+  currentTab = await fetchCurrentTab();
+  updateTabSummary(currentTab);
+}
+
+initCurrentTabPanel();


### PR DESCRIPTION
## Summary
- add a shared settings module defining time ranges, data types, and helpers
- implement the general options page form with automatic persistence and reset handling
- wire the popup current tab panel to show tab context and trigger scoped cleanup using the saved defaults

## Testing
- not run (extension-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e4b21f156c8331b660ab1936e1f919