### PR TITLE
Ensure general settings propagate to all panels

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -40,6 +40,7 @@ export const DEFAULT_GENERAL_SETTINGS = {
   automation: {
     enabled: false,
     threshold: 20,
+    browserEvent: BROWSER_EVENT_AUTOMATION[0],
   },
 };
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -9,6 +9,7 @@ import {
   DEFAULT_GENERAL_SETTINGS,
   normalizeGeneralSettings,
   AUTOMATION_THRESHOLD,
+  BROWSER_EVENT_AUTOMATION,
 } from "../common/settings.js";
 
 const STATUS_DURATION = 3200;
@@ -61,7 +62,9 @@ function readSettingsFromForm() {
     threshold: automationThresholdInput
       ? Number.parseInt(automationThresholdInput.value, 10)
       : currentSettings.automation.threshold,
-    browserEvent: currentSettings.automation.browserEvent,
+    browserEvent:
+      currentSettings.automation.browserEvent ||
+      BROWSER_EVENT_AUTOMATION[0],
   };
 
   const browserEventInput = formData.get("browserEvent");

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -13,6 +13,7 @@ import {
   derivePanelSelectionFromGeneral,
   normalizePanelSelection,
   AUTOMATION_THRESHOLD,
+  BROWSER_EVENT_AUTOMATION,
 } from "../common/settings.js";
 import { hasChromeRuntime } from "../common/utils.js";
 
@@ -357,6 +358,8 @@ async function initCurrentTabPanel() {
   observeGeneralSettings((nextGeneral) => {
     generalSettings = nextGeneral;
     generalDefaults = derivePanelSelectionFromGeneral(generalSettings);
+    panelSelection = normalizePanelSelection(panelSelection, generalDefaults);
+    applySettings(panelSelection);
   });
 }
 
@@ -545,6 +548,8 @@ async function initGlobalPanel() {
   observeGeneralSettings((nextGeneral) => {
     generalSettings = nextGeneral;
     generalDefaults = derivePanelSelectionFromGeneral(generalSettings);
+    panelSelection = normalizePanelSelection(panelSelection, generalDefaults);
+    applySettings(panelSelection);
   });
 }
 
@@ -621,6 +626,9 @@ async function initPopupSettingsPanel() {
       threshold: thresholdInput
         ? Number.parseInt(thresholdInput.value, 10)
         : currentSettings.automation.threshold,
+      browserEvent:
+        currentSettings.automation.browserEvent ??
+        BROWSER_EVENT_AUTOMATION[0],
     };
 
     return normalizeGeneralSettings({


### PR DESCRIPTION
## Summary
- add a default browser event to general settings and expose the option on both settings surfaces
- keep browser event selections when saving from the popup settings panel
- re-apply updated general defaults to the current tab and global cleanup panels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e4bf8ef9b08331af07900144786444