### PR TITLE
Update automation cleanup messaging and startup behavior

### DIFF
--- a/src/background/icon-service-worker.js
+++ b/src/background/icon-service-worker.js
@@ -85,10 +85,7 @@ async function runAutomatedCleanup(trigger) {
     );
 
     const preference = generalSettings.automation.browserEvent;
-    if (
-      (trigger === "startup" && preference !== "startup") ||
-      (trigger === "shutdown" && preference !== "shutdown")
-    ) {
+    if (trigger !== "startup" || preference !== "startup") {
       return;
     }
 
@@ -115,11 +112,7 @@ async function runAutomatedCleanup(trigger) {
       });
     });
 
-    console.info(
-      `[Tab Clean Master] 已在${
-        trigger === "startup" ? "浏览器启动" : "浏览器关闭"
-      }时执行默认清理。`
-    );
+    console.info("[Tab Clean Master] 已在浏览器启动时执行默认清理。");
   } catch (error) {
     console.error(
       `[Tab Clean Master] 自动清理执行失败（${trigger}）`,
@@ -137,6 +130,3 @@ chrome.runtime.onStartup.addListener(() => {
   runAutomatedCleanup("startup");
 });
 
-chrome.runtime.onSuspend.addListener(() => {
-  runAutomatedCleanup("shutdown");
-});

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -21,11 +21,7 @@ export const DATA_TYPE_OPTIONS = [
   { id: "downloads", label: "下载记录", key: "downloads", supportsOrigins: false },
   { id: "passwords", label: "已保存的密码", key: "passwords", supportsOrigins: false },
 ];
-export const BROWSER_EVENT_AUTOMATION = [
-  "off",
-  "startup",
-  "shutdown",
-];
+export const BROWSER_EVENT_AUTOMATION = ["off", "startup"];
 
 export const DEFAULT_GENERAL_SETTINGS = {
   timeRange: "lastHour",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -85,13 +85,17 @@
         <section class="options__section" aria-labelledby="section-automation">
           <div class="section__heading">
             <h2 id="section-automation">自动清理策略</h2>
-            <p>在达到指定条件时自动执行默认的清理策略。</p>
+            <p>
+              在标签页过多时执行一次默认清理。启用后，当所有标签页的数量
+              超过设定的阈值时会自动执行清理，并会在开启后首次打开新标签页
+              时检查标签页数量。
+            </p>
           </div>
           <div class="automation">
             <label class="switch">
               <input type="checkbox" data-automation="enabled" />
               <span class="switch__control" aria-hidden="true"></span>
-              <span class="switch__label">启用自动清理</span>
+              <span class="switch__label">启动自动清理功能</span>
             </label>
             <div class="automation__threshold">
               <label for="automation-threshold">标签页数量阈值</label>
@@ -105,7 +109,7 @@
                 data-automation="threshold"
               />
               <p class="automation__hint">
-                当打开的标签页数量超过该值时，将提示执行一次默认清理。
+                当打开的标签页数量超过该值时，将自动执行一次默认清理。
               </p>
             </div>
             <fieldset
@@ -117,7 +121,7 @@
                 浏览器事件自动清理
               </legend>
               <p class="automation__hint">
-                在打开或关闭浏览器时自动执行一次默认清理。默认保持关闭。
+                在打开浏览器时自动执行一次默认清理。默认保持关闭。
               </p>
               <div class="automation__event-options">
                 <label class="chip chip--dense">
@@ -126,11 +130,7 @@
                 </label>
                 <label class="chip chip--dense">
                   <input type="radio" name="browserEvent" value="startup" />
-                  <span>打开浏览器时</span>
-                </label>
-                <label class="chip chip--dense">
-                  <input type="radio" name="browserEvent" value="shutdown" />
-                  <span>关闭浏览器前</span>
+                  <span>打开</span>
                 </label>
               </div>
             </fieldset>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -275,12 +275,12 @@
             <section class="settings-panel__section" aria-labelledby="popup-settings-automation">
               <div class="settings-panel__heading">
                 <h3 id="popup-settings-automation">自动清理</h3>
-                <p>在标签页过多时提醒进行一次默认清理。</p>
+                <p>在标签页过多时执行一次默认清理。</p>
               </div>
               <label class="settings-panel__switch">
                 <input type="checkbox" data-settings-automation="enabled" />
                 <span class="settings-panel__switch-control" aria-hidden="true"></span>
-                <span class="settings-panel__switch-label">启用自动清理提醒</span>
+                <span class="settings-panel__switch-label">启动自动清理功能</span>
               </label>
               <div class="settings-panel__threshold">
                 <label for="popup-settings-threshold">标签页数量阈值</label>


### PR DESCRIPTION
## Summary
- adjust automation descriptions to reflect automatic cleanup when the tab count exceeds the threshold
- remove the shutdown browser event option and limit automated cleanup to browser startup
- update popup labels to highlight the automatic cleanup functionality

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e4c5b62d008331933fb82f597b2fdc